### PR TITLE
Speed up geofence group lookup

### DIFF
--- a/lib/geofence.js
+++ b/lib/geofence.js
@@ -60,31 +60,30 @@ Geofence.prototype = {
     },
 
     // Make a grid for this geofence using a given bound box and granularity.
-    // For each tile visited, the callback will be called with (hash, state) as
-    // arguments where state is either 'i', 'o', or 'x'.
-    makeGrid: function(boundBox, granularity, callback) {
+    // The function returns a dict of type {hash, state} as
+    // arguments where state is either 'i' or 'o'.
+    makeGrid: function(boundBox, granularity) {
 
-        var minX = boundBox.minX;
-        var minY = boundBox.minY;
-        var maxX = boundBox.maxX;
-        var maxY = boundBox.maxY;
+        var tileWidth = (boundBox.maxX - boundBox.minX) / granularity;
+        var tileHeight = (boundBox.maxY - boundBox.minY) / granularity;
 
-        var tileWidth = (maxX - minX) / granularity;
-        var tileHeight = (maxY - minY) / granularity;
-
-        var minTileX = this.minTileX = utils.project(minX, tileWidth);
-        var minTileY = this.minTileY = utils.project(minY, tileHeight);
-        var maxTileX = this.maxTileX = utils.project(maxX, tileWidth);
-        var maxTileY = this.maxTileY = utils.project(maxY, tileHeight);
+        var minTileX = utils.project(this.minX, tileWidth);
+        var minTileY = utils.project(this.minY, tileHeight);
+        var maxTileX = utils.project(this.maxX, tileWidth);
+        var maxTileY = utils.project(this.maxY, tileHeight);
 
         var bBoxPoly = null;
         var tileHash = null;
+        var result = {};
+
+        var hash0TileX = utils.project(boundBox.minX, tileWidth);
+        var hash0TileY = utils.project(boundBox.minY, tileHeight);
 
         // console.log("");
         for (var tileX = minTileX; tileX <= maxTileX; tileX++) {
             var row = '';
             for (var tileY = minTileY; tileY <= maxTileY; tileY++) {
-                tileHash = (tileY - minTileY) * granularity + (tileX - minTileX);
+                tileHash = (tileY - hash0TileY) * granularity + (tileX - hash0TileX);
                 bBoxPoly = [
                     [tileX * tileWidth, tileY * tileHeight],
                     [(tileX + 1) * tileWidth, tileY * tileHeight],
@@ -94,22 +93,21 @@ Geofence.prototype = {
                 ];
                 // console.log(tileHash, tileWidth, tileHeight, bBoxPoly);
                 if (utils.haveIntersectingEdges(bBoxPoly, this.vertices) || utils.hasPointInPolygon(this.vertices, bBoxPoly)) {
-                    callback(tileHash, 'x');
-                    row += 'x';
+                    result[tileHash] = 'x';
+                    //row += 'x';
                 // If the geofence doesn't have any points inside the tile bbox, then if the bbox has any point inside the geofence
                 // the bbox has all the points inside the geofence
                 } else if (utils.hasPointInPolygon(bBoxPoly, this.vertices)) {
-                    callback(tileHash, 'i');
-                    row += 'i';
+                    result[tileHash] = 'i';
+                    //row += 'i';
                 } // else all points are outside the poly
                 else {
-                    callback(tileHash, 'o');
-                    row += 'o';
+                    //row += 'o';
                 }
             }
             //console.log(row);
-        } 
-        return;
+        }
+        return result;
     },
 
     setInclusionTiles: function() {
@@ -124,12 +122,12 @@ Geofence.prototype = {
         this.tileWidth = (maxX - minX) / this.granularity;
         this.tileHeight = (maxY - minY) / this.granularity;
 
-        var tiles = this.tiles;
-        this.makeGrid({minX: minX, minY: minY, maxX: maxX, maxY: maxY},
-            this.granularity,
-            function(hash, state) {
-                tiles[hash] = state;
-            });
+        this.minTileX = utils.project(minX, this.tileWidth);
+        this.minTileY = utils.project(minY, this.tileHeight);
+        this.maxTileX = utils.project(maxX, this.tileWidth);
+        this.maxTileY = utils.project(maxY, this.tileHeight);
+        
+        this.tiles = this.makeGrid(this, this.granularity);
     }
 };
 

--- a/lib/geofence.js
+++ b/lib/geofence.js
@@ -59,20 +59,18 @@ Geofence.prototype = {
         }
     },
 
-    setInclusionTiles: function() {
-        var xVertices = this.vertices.map(function(point) { return point[0];});
-        var yVertices = this.vertices.map(function(point) { return point[1];});
+    // Make a grid for this geofence using a given bound box and granularity.
+    // For each tile visited, the callback will be called with (hash, state) as
+    // arguments where state is either 'i', 'o', or 'x'.
+    makeGrid: function(boundBox, granularity, callback) {
 
-        var minX = this.minX = Math.min.apply(null, xVertices);
-        var minY = this.minY = Math.min.apply(null, yVertices);
-        var maxX = this.maxX = Math.max.apply(null, xVertices);
-        var maxY = this.maxY = Math.max.apply(null, yVertices);
+        var minX = boundBox.minX;
+        var minY = boundBox.minY;
+        var maxX = boundBox.maxX;
+        var maxY = boundBox.maxY;
 
-        var xRange = maxX - minX;
-        var yRange = maxY - minY;
-
-        var tileWidth = this.tileWidth = xRange / this.granularity;
-        var tileHeight = this.tileHeight = yRange / this.granularity;
+        var tileWidth = (maxX - minX) / granularity;
+        var tileHeight = (maxY - minY) / granularity;
 
         var minTileX = this.minTileX = utils.project(minX, tileWidth);
         var minTileY = this.minTileY = utils.project(minY, tileHeight);
@@ -84,9 +82,9 @@ Geofence.prototype = {
 
         // console.log("");
         for (var tileX = minTileX; tileX <= maxTileX; tileX++) {
-            // var row = '';
+            var row = '';
             for (var tileY = minTileY; tileY <= maxTileY; tileY++) {
-                tileHash = (tileY - minTileY) * this.granularity + (tileX - minTileX);
+                tileHash = (tileY - minTileY) * granularity + (tileX - minTileX);
                 bBoxPoly = [
                     [tileX * tileWidth, tileY * tileHeight],
                     [(tileX + 1) * tileWidth, tileY * tileHeight],
@@ -94,24 +92,44 @@ Geofence.prototype = {
                     [tileX * tileWidth, (tileY + 1) * tileHeight],
                     [tileX * tileWidth, tileY * tileHeight]
                 ];
-
+                // console.log(tileHash, tileWidth, tileHeight, bBoxPoly);
                 if (utils.haveIntersectingEdges(bBoxPoly, this.vertices) || utils.hasPointInPolygon(this.vertices, bBoxPoly)) {
-                    this.tiles[tileHash] = 'x';
-                    // row += 'x';
+                    callback(tileHash, 'x');
+                    row += 'x';
                 // If the geofence doesn't have any points inside the tile bbox, then if the bbox has any point inside the geofence
                 // the bbox has all the points inside the geofence
                 } else if (utils.hasPointInPolygon(bBoxPoly, this.vertices)) {
-                    this.tiles[tileHash] = 'i';
-                    // row += 'i';
+                    callback(tileHash, 'i');
+                    row += 'i';
                 } // else all points are outside the poly
                 else {
-                    // row += '.';
+                    callback(tileHash, 'o');
+                    row += 'o';
                 }
             }
-            // console.log(row);
-        }
-
+            //console.log(row);
+        } 
         return;
+    },
+
+    setInclusionTiles: function() {
+        var xVertices = this.vertices.map(function(point) { return point[0];});
+        var yVertices = this.vertices.map(function(point) { return point[1];});
+
+        var minX = this.minX = Math.min.apply(null, xVertices);
+        var minY = this.minY = Math.min.apply(null, yVertices);
+        var maxX = this.maxX = Math.max.apply(null, xVertices);
+        var maxY = this.maxY = Math.max.apply(null, yVertices);
+
+        this.tileWidth = (maxX - minX) / this.granularity;
+        this.tileHeight = (maxY - minY) / this.granularity;
+
+        var tiles = this.tiles;
+        this.makeGrid({minX: minX, minY: minY, maxX: maxX, maxY: maxY},
+            this.granularity,
+            function(hash, state) {
+                tiles[hash] = state;
+            });
     }
 };
 

--- a/lib/geofenced_group.js
+++ b/lib/geofenced_group.js
@@ -12,9 +12,6 @@ var Entry = function(id, whiteoutGfs, blackoutGfs) {
         // should assert false?
         return this;
     }
-
-    this.minX = this.minY = Infinity;
-    this.maxX = this.maxY = -Infinity;
     if (whiteoutGfs) {
         for (var i = 0; i < whiteoutGfs.length; i++) {
             this.minX = Math.min(this.minX, whiteoutGfs[i].minX);
@@ -44,21 +41,18 @@ var GeofencedGroup = function(granularity) {
     this.maxX = this.maxY = -Infinity;
     this.tileWidth = null;
     this.tileHeight = null;
-    // left-bottom point for the master grid. Following the same way Geofence
-    // creates the grid, this point is different than [minX, minY]
-    this.minGridX = this.minGridY = null;
 
-    // We use three sets keeps track of the Ids for each tile
-    // tiles['w'][X] is the Ids that white out the tile X
-    // tiles['b'][X] is the Ids that black out the tile
-    // tiles['?'][X] is the Ids that need to be verified by calling inside()
-    this.tiles = {'w': [], 'b': [], '?': []};
-    this.blackOnlyIds = {};
+    this.tiles = [];
+    this.blackOnlyIds = [];
+
     return this;
 };
 
 GeofencedGroup.prototype = {
     add: function(id, whiteoutGfs, blackoutGfs) {
+        if (typeof id !== "number") {
+            return;
+        }
         this.remove(id);
         var entry = new Entry(id, whiteoutGfs, blackoutGfs);
         this.updateMasterGrid(entry);
@@ -69,71 +63,44 @@ GeofencedGroup.prototype = {
 
     remove: function(id) {
         delete this.entries[id];
-        var removeId = function(arr, id) {
-            for (var i = 0; i < arr.length; i++) {
-                if (typeof arr[i] != "undefined") {
-                    delete arr[i][id];
+        for (var i = 0; i < this.tiles.length; i++) {
+            if (typeof this.tiles[i] !== "undefined") {
+                var index = this.tiles[i].indexOf(id);
+                if (index !== -1) {
+                    this.tiles[i].splice(index, 1);
                 }
             }
         }
-        removeId(this.tiles['w'], id);
-        removeId(this.tiles['b'], id);
-        removeId(this.tiles['?'], id);
-        delete this.blackOnlyIds[id];
+        index = this.blackOnlyIds.indexOf(id);
+        if (index !== -1) {
+            this.blackOnlyIds.splice(index, 1);
+        }
     },
 
     // Add a new entry to the master grid. This method will call
     // makeGrid for the entry using the master grid and put each tile of the master grid
-    // in the 'w', 'b', or '?' sets
     addEntryToMasterGrid: function(entry) {
-        var tiles = this.tiles;
-        boundBox = {minX: this.minX, minY: this.minY, maxX: this.maxX, maxY: this.maxY};
-        var addId = function(arr, hash, id) {
-            if (typeof arr[hash] == "undefined") {
-                arr[hash] = {}
-            }
-            arr[hash][id] = true;
-        }
- 
-        var hasId = function(arr, hash, id) {
-            return (typeof arr[hash] != "undefined") && (id in arr[hash]);
-        }
   
-        if (entry.blackouts) {
-            for (var i = 0; i < entry.blackouts.length; i++) {
-                entry.blackouts[i].makeGrid(boundBox, this.granularity,
-                    function(hash, state) {
-                        // console.log("add blackouts hash=" + hash + ", state=" + state);
-                        if (state === 'i') {
-                            addId(tiles['b'], hash, entry.id);
-                        } else if (state === 'x') {
-                            addId(tiles['?'], hash, entry.id);
-                        }
+        var allGfs = [].concat(entry.blackouts, entry.whiteouts);
+
+        for (var i = 0; i < allGfs.length; i++) {
+            var oneGfTiles = allGfs[i] && allGfs[i].makeGrid(this, this.granularity);
+            for (var hash in oneGfTiles) {
+                if (oneGfTiles[hash] === 'i' || oneGfTiles[hash] === 'x') {
+                    if (typeof this.tiles[hash] == "undefined") {
+                        this.tiles[hash] = [];
                     }
-                );
+                    //console.log("Hash " + hash + " contains id " + allGfs[i].id);
+                    if (this.tiles[hash].indexOf(entry.id) === -1) {
+                        this.tiles[hash].push(entry.id);
+                    }
+                }
             }
         }
-        
+
         if (!entry.whiteouts || entry.whiteouts.length === 0) {
-            this.blackOnlyIds[entry.id] = true;
+            this.blackOnlyIds.push(entry.id);
         }
-
-        if (entry.whiteouts) {
-            for (var i = 0; i < entry.whiteouts.length; i++) {
-                entry.whiteouts[i].makeGrid(boundBox, this.granularity,
-                    function(hash, state) {
-                        if (state === 'i' && !hasId(tiles['b'], hash, entry.id) &&
-                            !hasId(tiles['?'], hash, entry.id)) {
-                            addId(tiles['w'], hash, entry.id);
-                        } else if (state === 'x' && !hasId(tiles['b'], hash, entry.id) &&
-                            !hasId(tiles['w'], hash, entry.id)) {
-                            addId(tiles['?'], hash, entry.id);
-                        }
-                    }
-                );
-            }
-        }
-
     },
 
     // Update the master grid with a new entry. If the new entry cannot be
@@ -147,8 +114,9 @@ GeofencedGroup.prototype = {
             return;
         }
 
-        //console.dir(entry);
+        //console.dir("Updating master grid with entry " + entry.id);
         //console.log(this.minX, this.minY, this.maxX, this.maxY);
+        
         // update grids and re-add all existing entries
         this.minX = Math.min(this.minX, entry.minX);
         this.maxX = Math.max(this.maxX, entry.maxX);
@@ -156,10 +124,11 @@ GeofencedGroup.prototype = {
         this.maxY = Math.max(this.maxY, entry.maxY);
         this.tileWidth = (this.maxX - this.minX) / this.granularity;
         this.tileHeight = (this.maxY - this.minY) / this.granularity;
-        this.minGridX = utils.project(this.minX, this.tileWidth) * this.tileWidth;
-        this.minGridY = utils.project(this.minY, this.tileHeight) * this.tileHeight;
-        this.tiles = {'w': [], 'b': [], '?': []};
-        this.blackOnlyIds = {};
+        this.minTileX = utils.project(this.minX, this.tileWidth);
+        this.minTileY = utils.project(this.minY, this.tileHeight);
+      
+        this.tiles = [];
+        this.blackOnlyIds = [];
 
         for (var id in this.entries) {
             this.addEntryToMasterGrid(this.entries[id]);
@@ -196,57 +165,42 @@ GeofencedGroup.prototype = {
             return [];
         }
         
-        var result = {}
-        // start with blackOnlyIds
-        for (var id in this.blackOnlyIds) {
-            result[id] = true;
-        }
+        var result = [];
+        var blacks = []; // verified to be blacked out Ids in the hashed tile
 
-        // if out of the boundBox, return all blackOnly Ids
         if (point[0] < this.minX || point[0] > this.maxX ||
             point[1] < this.minY || point[1] > this.maxY) {
-            return Object.keys(result).map(Number);
+            return this.blackOnlyIds;
         }
-       
-        var hash = Math.floor((point[1] - this.minGridY) / this.tileHeight) * this.granularity
-            + Math.floor((point[0] - this.minGridX) / this.tileWidth);
 
+        var hash = (utils.project(point[1], this.tileHeight) - this.minTileY) * this.granularity
+            + (utils.project(point[0], this.tileWidth) - this.minTileX);
+
+        if (typeof this.tiles[hash] === "undefined") {
+            return this.blackOnlyIds;
+        }
+        //console.log("Hash: %d", tileHash);
+        //console.log("point = " + point + ", hash = " + hash + ", bOnly = " + this.blackOnlyIds);
+        //console.dir(this.tiles[hash]);
+        
         // the valid Ids for this tile is determined in the following way
-        // blackOnlyIds + (Ids in 'w' set) - (Ids in 'b' set)
-        //     + (confirmed Ids in '?' set) - (negatively conformed Ids in '?' set)
-        var tiles = this.tiles;
-        var entries = this.entries;
-
-        //console.log("point = " + point + ", hash = " + hash + ", blackOnly = " + Object.keys(result));
-        //console.dir(tiles['w'][hash]);
-        //console.dir(tiles['b'][hash]);
-        //console.dir(tiles['?'][hash]);
-
-        for (var id in tiles['w'][hash]) {
-            result[id] = true;
-        }
-
-        //console.log(result);
-        for (var id in tiles['?'][hash]) {
-            if (GeofencedGroup.isPointValid(point, entries[id].whiteouts, entries[id].blackouts)) {
-                result[id] = true;
+        // blackOnlyIds + (confirmed Ids in tiles[hash]) - (negatively conformed in tiles[hash])
+        for (var i in this.tiles[hash]) {
+            var id = this.tiles[hash][i];
+            if (GeofencedGroup.isPointValid(point, this.entries[id].whiteouts, this.entries[id].blackouts)) {
+                result.push(id);
             } else {
-                delete result[id];
+                blacks.push(id);
             }
         }
-            
-        for (var id in tiles['b'][hash]) {
-            delete result[id];
+
+        for (var i in this.blackOnlyIds) {
+            if (blacks.indexOf(this.blackOnlyIds[i]) === -1 && result.indexOf(this.blackOnlyIds[i]) === -1) {
+                result.push(this.blackOnlyIds[i]);
+            }
         }
 
-        //return Object.keys(result).map(Number).sort(function(a, b) { return a - b; });
-        // map() is slower than straightforward loop
-        var arr = [];
-        for (var id in result) {
-            arr.push(Number(id));
-        }
-
-        return arr;
+        return result;
     }
 };
 

--- a/lib/geofenced_group.js
+++ b/lib/geofenced_group.js
@@ -1,57 +1,252 @@
 var Geofence = require('./geofence');
+var utils = require('./utils');
 
 var Entry = function(id, whiteoutGfs, blackoutGfs) {
     this.id = id;
     this.whiteouts = whiteoutGfs;
     this.blackouts = blackoutGfs;
+    this.minX = this.minY = Infinity;
+    this.maxX = this.maxY = -Infinity;
+    
+    if (whiteoutGfs == false && blackoutGfs == false) {
+        // should assert false?
+        return this;
+    }
+
+    this.minX = this.minY = Infinity;
+    this.maxX = this.maxY = -Infinity;
+    if (whiteoutGfs) {
+        for (var i = 0; i < whiteoutGfs.length; i++) {
+            this.minX = Math.min(this.minX, whiteoutGfs[i].minX);
+            this.minY = Math.min(this.minY, whiteoutGfs[i].minY);
+            this.maxX = Math.max(this.maxX, whiteoutGfs[i].maxX);
+            this.maxY = Math.max(this.maxY, whiteoutGfs[i].maxY);
+        }
+    }
+    if (blackoutGfs) {
+        for (var i = 0; i < blackoutGfs.length; i++) {
+            this.minX = Math.min(this.minX, blackoutGfs[i].minX);
+            this.minY = Math.min(this.minY, blackoutGfs[i].minY);
+            this.maxX = Math.max(this.maxX, blackoutGfs[i].maxX);
+            this.maxY = Math.max(this.maxY, blackoutGfs[i].maxY);
+        }
+    }
 
     return this;
 };
 
-var GeofencedGroup = function() {
-    this.entries = [];
+var GeofencedGroup = function(granularity) {
+    this.entries = {};
+    // A group has a master grid
+    this.granularity = Math.floor(granularity) || 10;
+    // bound box for all the geofences
+    this.minX = this.minY = Infinity;
+    this.maxX = this.maxY = -Infinity;
+    this.tileWidth = null;
+    this.tileHeight = null;
+    // left-bottom point for the master grid. Following the same way Geofence
+    // creates the grid, this point is different than [minX, minY]
+    this.minGridX = this.minGridY = null;
 
+    // We use three sets keeps track of the Ids for each tile
+    // tiles['w'][X] is the Ids that white out the tile X
+    // tiles['b'][X] is the Ids that black out the tile
+    // tiles['?'][X] is the Ids that need to be verified by calling inside()
+    this.tiles = {'w': [], 'b': [], '?': []};
+    this.blackOnlyIds = {};
     return this;
 };
 
 GeofencedGroup.prototype = {
     add: function(id, whiteoutGfs, blackoutGfs) {
-        for (var x = 0; x < this.entries.length; x++) {
-            if (this.entries[x].id === id) {
-                this.entries.splice(x, 1);
-                return;
-            }
-        }
-
-        this.entries.push(new Entry(id, whiteoutGfs, blackoutGfs));
-
+        this.remove(id);
+        var entry = new Entry(id, whiteoutGfs, blackoutGfs);
+        this.updateMasterGrid(entry);
+        this.addEntryToMasterGrid(entry);
+        this.entries[entry.id] = entry;
         return;
     },
 
-    isValidKey: function(point, id) {
-        var entry = null;
-        for (var x = 0; x < this.entries.length; x++) {
-            entry = this.entries[x];
-            if (entry.id === id) {
-                return GeofencedGroup.isPointValid(point, entry.whiteouts, entry.blackouts);
+    remove: function(id) {
+        delete this.entries[id];
+        var removeId = function(arr, id) {
+            for (var i = 0; i < arr.length; i++) {
+                if (typeof arr[i] != "undefined") {
+                    delete arr[i][id];
+                }
+            }
+        }
+        removeId(this.tiles['w'], id);
+        removeId(this.tiles['b'], id);
+        removeId(this.tiles['?'], id);
+        delete this.blackOnlyIds[id];
+    },
+
+    // Add a new entry to the master grid. This method will call
+    // makeGrid for the entry using the master grid and put each tile of the master grid
+    // in the 'w', 'b', or '?' sets
+    addEntryToMasterGrid: function(entry) {
+        var tiles = this.tiles;
+        boundBox = {minX: this.minX, minY: this.minY, maxX: this.maxX, maxY: this.maxY};
+        var addId = function(arr, hash, id) {
+            if (typeof arr[hash] == "undefined") {
+                arr[hash] = {}
+            }
+            arr[hash][id] = true;
+        }
+ 
+        var hasId = function(arr, hash, id) {
+            return (typeof arr[hash] != "undefined") && (id in arr[hash]);
+        }
+  
+        if (entry.blackouts) {
+            for (var i = 0; i < entry.blackouts.length; i++) {
+                entry.blackouts[i].makeGrid(boundBox, this.granularity,
+                    function(hash, state) {
+                        // console.log("add blackouts hash=" + hash + ", state=" + state);
+                        if (state === 'i') {
+                            addId(tiles['b'], hash, entry.id);
+                        } else if (state === 'x') {
+                            addId(tiles['?'], hash, entry.id);
+                        }
+                    }
+                );
+            }
+        }
+        
+        if (!entry.whiteouts || entry.whiteouts.length === 0) {
+            this.blackOnlyIds[entry.id] = true;
+        }
+
+        if (entry.whiteouts) {
+            for (var i = 0; i < entry.whiteouts.length; i++) {
+                entry.whiteouts[i].makeGrid(boundBox, this.granularity,
+                    function(hash, state) {
+                        if (state === 'i' && !hasId(tiles['b'], hash, entry.id) &&
+                            !hasId(tiles['?'], hash, entry.id)) {
+                            addId(tiles['w'], hash, entry.id);
+                        } else if (state === 'x' && !hasId(tiles['b'], hash, entry.id) &&
+                            !hasId(tiles['w'], hash, entry.id)) {
+                            addId(tiles['?'], hash, entry.id);
+                        }
+                    }
+                );
             }
         }
 
-        return false;
     },
 
-    getValidKeys: function(point) {
+    // Update the master grid with a new entry. If the new entry cannot be
+    // contained with existing bbox, then we will change the bbox, and re-gridify
+    // all existing entries according to the new bbox.
+    updateMasterGrid: function(entry) {
+        if (this.minX <= entry.minX && this.minY <= entry.minY
+            && this.maxX >= entry.maxX && this.maxY >= entry.maxY) {
+            // no need to update, current master grids covers
+            //console.log("entry " + entry.id + " is contained in existing bbox");
+            return;
+        }
+
+        //console.dir(entry);
+        //console.log(this.minX, this.minY, this.maxX, this.maxY);
+        // update grids and re-add all existing entries
+        this.minX = Math.min(this.minX, entry.minX);
+        this.maxX = Math.max(this.maxX, entry.maxX);
+        this.minY = Math.min(this.minY, entry.minY);
+        this.maxY = Math.max(this.maxY, entry.maxY);
+        this.tileWidth = (this.maxX - this.minX) / this.granularity;
+        this.tileHeight = (this.maxY - this.minY) / this.granularity;
+        this.minGridX = utils.project(this.minX, this.tileWidth) * this.tileWidth;
+        this.minGridY = utils.project(this.minY, this.tileHeight) * this.tileHeight;
+        this.tiles = {'w': [], 'b': [], '?': []};
+        this.blackOnlyIds = {};
+
+        for (var id in this.entries) {
+            this.addEntryToMasterGrid(this.entries[id]);
+        }
+
+        //console.log("bound box changes after adding entry " + entry.id);
+    },
+    
+    isValidKey: function(point, id) {
+        var entry = null;
+        if (!id in this.entries) {
+            return false;
+        }
+        return GeofencedGroup.isPointValid(point, entry[id].whiteouts, entry[id].blackouts);
+    },
+
+    // This is the brute force implementation that does not use master grid
+    getValidKeysBF: function(point) {
         var valid = [];
         var entry = null;
 
-        for (var x = 0; x < this.entries.length; x++) {
-            entry = this.entries[x];
+        for (var id in this.entries) {
+            entry = this.entries[id];
             if (GeofencedGroup.isPointValid(point, entry.whiteouts, entry.blackouts)) {
                 valid.push(entry.id);
             }
         }
 
         return valid;
+    },
+
+    getValidKeys: function(point) {
+        if (!this.entries) {
+            return [];
+        }
+        
+        var result = {}
+        // start with blackOnlyIds
+        for (var id in this.blackOnlyIds) {
+            result[id] = true;
+        }
+
+        // if out of the boundBox, return all blackOnly Ids
+        if (point[0] < this.minX || point[0] > this.maxX ||
+            point[1] < this.minY || point[1] > this.maxY) {
+            return Object.keys(result).map(Number);
+        }
+       
+        var hash = Math.floor((point[1] - this.minGridY) / this.tileHeight) * this.granularity
+            + Math.floor((point[0] - this.minGridX) / this.tileWidth);
+
+        // the valid Ids for this tile is determined in the following way
+        // blackOnlyIds + (Ids in 'w' set) - (Ids in 'b' set)
+        //     + (confirmed Ids in '?' set) - (negatively conformed Ids in '?' set)
+        var tiles = this.tiles;
+        var entries = this.entries;
+
+        //console.log("point = " + point + ", hash = " + hash + ", blackOnly = " + Object.keys(result));
+        //console.dir(tiles['w'][hash]);
+        //console.dir(tiles['b'][hash]);
+        //console.dir(tiles['?'][hash]);
+
+        for (var id in tiles['w'][hash]) {
+            result[id] = true;
+        }
+
+        //console.log(result);
+        for (var id in tiles['?'][hash]) {
+            if (GeofencedGroup.isPointValid(point, entries[id].whiteouts, entries[id].blackouts)) {
+                result[id] = true;
+            } else {
+                delete result[id];
+            }
+        }
+            
+        for (var id in tiles['b'][hash]) {
+            delete result[id];
+        }
+
+        //return Object.keys(result).map(Number).sort(function(a, b) { return a - b; });
+        // map() is slower than straightforward loop
+        var arr = [];
+        for (var id in result) {
+            arr.push(Number(id));
+        }
+
+        return arr;
     }
 };
 
@@ -62,6 +257,7 @@ GeofencedGroup.isPointValid = function(point, whiteoutGfs, blackoutGfs) {
     if (blackoutGfs) {
         for (x = 0; x < blackoutGfs.length; x++) {
             if (blackoutGfs[x].inside(point)) {
+                //console.log("point " + point + " blackout by #" + x);
                 return false;
             }
         }
@@ -71,6 +267,7 @@ GeofencedGroup.isPointValid = function(point, whiteoutGfs, blackoutGfs) {
     if (whiteoutGfs && whiteoutGfs.length) {
         for (x = 0; x < whiteoutGfs.length; x++) {
             if (whiteoutGfs[x].inside(point)) {
+                //console.log("point " + point + " whiteout by #" + whiteoutGfs[x].vertices);
                 return true;
             }
         }

--- a/test/test_geofence.js
+++ b/test/test_geofence.js
@@ -23,6 +23,14 @@ describe('Geofence.inside()', function() {
             point = randomPoint(2000);
             expect(gf.inside(point)).to.equal(utils.pointInPolygon(point, polygon));
         }
+
+        // This example shows a potential bug 
+        polygon = [[-2.3876149989664555,3.379635098390281],
+            [-8.781455275197889,0.17502455545495943],
+            [-10.377099824721249,3.089788889044276]];
+        gf = new geofence(polygon, 4);
+        point = [-9.242811576841252,1.346647631356851];
+        expect(gf.inside(point)).to.equal(utils.pointInPolygon(point, polygon));
     });
 
     it('should be faster than utils.pointInPolygon', function() {

--- a/test/test_geofenced_group.js
+++ b/test/test_geofenced_group.js
@@ -37,4 +37,13 @@ describe('GeofencedGroup.getValid()', function() {
     it('a point in blackout 2 should include 2, 3', function() {
         expect(gfg.getValidKeys([55, 25])).to.deep.equal([2, 3]);
     });
+
+    it('entry deletion should work', function() {
+        gfg.remove(2);
+        expect(gfg.getValidKeys([55, 25])).to.deep.equal([3]);
+
+        gfg.remove(3);
+        expect(gfg.getValidKeys([55, 25])).to.deep.equal([]);
+    });
+
 });

--- a/test/test_group_optimization.js
+++ b/test/test_group_optimization.js
@@ -1,0 +1,147 @@
+var expect = require('chai').expect;
+
+var utils = require('../lib/utils');
+var Geofence = require('../lib/geofence');
+var GeofencedGroup = require('../lib/geofenced_group');
+
+// Spec object to create random polygon
+var PolygonSpec = function() {
+    this.centerXRange = [0, 0]; 
+    this.centerYRange = [0, 0]; 
+    this.sidesRange = [3, 8];
+    this.radiusRange = [1, 4];
+    this.convex = true;
+};
+
+// Spec object to create a random geofence group
+var GroupSpec = function() {
+    this.minX = -10;
+    this.minY = -10;
+    this.maxX = 10;
+    this.maxY = 10;
+    this.granularity = 20;
+    this.entries = 100;
+    this.whiteGfRange = [0, 10];
+    this.blackGfRange = [0, 10];
+};
+
+// Generate a random polygon with non-intersecting edges in the following way
+// 1. Create random angles in [0..360], fix two as 0, and 180
+// 2. Draw a line with random length(radius) from [0,0] using one angle, the other
+//    end of the line is a verticle of the polygon. For convex polygon, use fixed radius.
+var generateRandomPolygon = function(spec) {
+
+    var angles = [0, 180];
+    var sides = spec.sidesRange[0] + Math.floor(Math.random() * (spec.sidesRange[1] - spec.sidesRange[0]));
+    for (var i = 0; i < sides - 2; i++) {
+        angles.push(Math.random() * 360);
+    }
+    angles = angles.sort();
+
+    var centerX = spec.centerXRange[0] + Math.random() * (spec.centerXRange[1] - spec.centerXRange[0]);
+    var centerY = spec.centerYRange[0] + Math.random() * (spec.centerYRange[1] - spec.centerYRange[0]);
+    var vertices = [];
+    for (var i = 0; i < angles.length; i++) {
+        var radius = spec.convex ? spec.radiusRange[0] :
+            spec.radiusRange[0] + Math.random() * (spec.radiusRange[1] - spec.radiusRange[0]);
+
+        var x = centerX +  Math.cos(angles[i]) * radius;
+        var y = centerY +  Math.sin(angles[i]) * radius;
+        vertices.push([x, y]);
+    }
+    return vertices;
+};
+
+// Generate a random geofence group
+var generateRandomGroup = function(groupSpec, polySpec) {
+
+    var gfg = new GeofencedGroup(groupSpec.granularity);
+    polySpec.centerXRange = [groupSpec.minX, groupSpec.maxX];
+    polySpec.centerYRange = [groupSpec.minY, groupSpec.maxY];
+
+    for (var i = 0; i < groupSpec.entries; i++) {
+        var whites = [];
+        var blacks = [];
+        var numWhites = groupSpec.whiteGfRange[0] + Math.floor(
+            Math.random() * (groupSpec.whiteGfRange[1] - groupSpec.whiteGfRange[0]));
+        var numBlacks = groupSpec.blackGfRange[0] + Math.floor(
+            Math.random() * (groupSpec.blackGfRange[1] - groupSpec.blackGfRange[0]));
+
+        for (var x = 0; x < numWhites; x++) {
+            var poly = generateRandomPolygon(polySpec);
+            whites.push(new Geofence(poly));
+        }
+
+        for (var x = 0; x < numBlacks; x++) {
+            var poly = generateRandomPolygon(polySpec);
+            blacks.push(new Geofence(poly));
+        }
+
+        gfg.add(i, whites, blacks);
+    }
+
+    return gfg;
+}
+
+describe('GeofencedGroup.getValideKeys', function() {
+    
+    it('correctness of fast lookup', function() {
+        var polySpec = new PolygonSpec();
+        var groupSpec = new GroupSpec();
+        var group = generateRandomGroup(groupSpec, polySpec);
+        for (var i = 0; i < 10000; i++) {
+            var randPoint = [group.minX + Math.random() * (group.maxX - group.minX),
+                group.minY + Math.random() * (group.maxY - group.minY)];
+            var ids1 = group.getValidKeys(randPoint);
+            var ids2 = group.getValidKeysBF(randPoint);
+            expect(ids1.sort()).to.deep.equal(ids2.sort());
+        }
+    });
+   
+    it('GeofencedGroup.performance', function() {
+
+        var polySpec = new PolygonSpec();
+        var groupSpec = new GroupSpec();
+
+        var group = generateRandomGroup(groupSpec, polySpec);
+
+        var numUnknownTiles = 0;
+        for (var x in group.tiles['?']) {
+            numUnknownTiles += (group.tiles['?'][x] ? Object.keys(group.tiles['?'][x]).length : 0);
+        }
+        console.log("Average unknown Ids per Tile " +
+            numUnknownTiles / (group.granularity * group.granularity));
+       
+        var iterations = 100000;
+        var points = [];
+        var timeFunction = function(fn, iterations) {
+            var start = Date.now();
+            for (var x = 0; x < iterations; x++) {
+                fn(x);
+            }
+            return Date.now() - start;
+        };
+
+        for (var i = 0; i < iterations; i++) {
+            var randPoint = [group.minX + Math.random() * (group.maxX - group.minX),
+                group.minY + Math.random() * (group.maxY - group.minY)];
+            points.push(randPoint);
+        }
+
+        var fastTime = timeFunction(function(i) {
+            group.getValidKeys(points[i]);
+        }, iterations);
+
+        var slowTime = timeFunction(function(i) {
+            group.getValidKeysBF(points[i]);
+        }, iterations);
+
+        //expect(fastTime).to.be.below(slowTime);
+        console.dir(groupSpec);
+        console.log("iterations: %d, AFTER optimization: %dms, BEFORE optimization: %dms",
+            iterations, fastTime, slowTime);
+    }); 
+       
+});
+
+


### PR DESCRIPTION
This change is an attempts to speed up geofence group lookup.
The idea is to create a master grid where each tile tracks the subset
of candidate entries in the group. The master grid is updated when a
new group is joined. An entry might be in at most one of the three
states w.r.t. a specific tile:
'w': means the entry whiteout the whole tile
'b': means the entry blackout the whole tile
'?': not sure.
To do look up Ids for a given point, we will inspect all entries in
the '?' set for the point's tile, and combine that with 'w' and 'b'
set to get the answer.

The change contains the following specific changes
- Refactor Geofence gridify routine (makeGrid) so that it can be
  reused by the master grid.
- Add support for removing an entry, fix a bug in original add routine.
- Implement fast lookup method. The method does not guarantee order of the returned Ids.
- Add a new test for both correctness and performance gain of the optimization.
- Add a test in test_geofence to illustrate a potential bug in geofence.inside().
