### PR TITLE
Cache Hit/Miss Events

### DIFF
--- a/lib/geofence.js
+++ b/lib/geofence.js
@@ -1,7 +1,10 @@
 var utils = require('./utils');
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
 var version = require('../package.json').version;
 
-var Geofence = function(vertices, granularity, tiles) {
+function Geofence(vertices, granularity, tiles) {
+    EventEmitter.call(this);
     if (!Array.isArray(vertices)) {
         throw new Error("Vertices must be an array");
     }
@@ -54,132 +57,136 @@ var Geofence = function(vertices, granularity, tiles) {
     // this.testsOutside = 0;
     // this.testsIntersecting = 0;
     // this.timeHashing = 0;
+}
+
+util.inherits(Geofence, EventEmitter);
+
+Geofence.prototype.inside = function(point) {
+    // Bbox check first
+    if (point[0] < this.minX || point[0] > this.maxX || point[1] < this.minY || point[1] > this.maxY) {
+        this.emit('outside', point);
+        // console.log("Outside Bbox: minX: %d, x: %d, maxX: %d, minY: %d, y: %d, maxY: %d", this.minX, point[0], this.maxX, this.minY, point[1], this.maxY);
+        return false;
+    }
+
+    // var hashStart = Date.now();
+    var tileHash = (utils.project(point[1], this.tileHeight) - this.minTileY) * this.granularity + (utils.project(point[0], this.tileWidth) - this.minTileX);
+    // console.log("Hash: %d", tileHash);
+    // var hashStart = Date.now();
+    var intersects = this.tiles[tileHash];
+    // this.timeHashing += Date.now() - hashStart;
+
+    if (intersects === 'i') {
+        this.emit('inside', point);
+        // this.testsInside++;
+        return true;
+    } else if (intersects === 'x') {
+        this.emit('intersection', point);
+        // this.testsIntersecting++;
+        var inside = utils.pointInPolygon(point, this.vertices);
+        if (!inside || !this.holes) {
+            return inside;
+        }
+        // If we do have holes cut out, and the point falls within the outer
+        // ring, ensure no inner rings exclude this point
+        for (var i = 0, hole; hole = this.holes[i]; i++) {
+            if (utils.pointInPolygon(point, hole)) {
+                return false;
+            }
+        }
+        return true;
+    } else {
+        this.emit('outside', point);
+        // this.testsOutside++;
+        return false;
+    }
 };
 
-Geofence.prototype = {
-    inside: function (point) {
-        // Bbox check first
-        if (point[0] < this.minX || point[0] > this.maxX || point[1] < this.minY || point[1] > this.maxY) {
-            // console.log("Outside Bbox: minX: %d, x: %d, maxX: %d, minY: %d, y: %d, maxY: %d", this.minX, point[0], this.maxX, this.minY, point[1], this.maxY);
-            return false;
-        }
+Geofence.prototype.setInclusionTiles = function() {
+    var xVertices = this.vertices.map(function(point) { return point[0]; });
+    var yVertices = this.vertices.map(function(point) { return point[1]; });
 
-        // var hashStart = Date.now();
-        var tileHash = (utils.project(point[1], this.tileHeight) - this.minTileY) * this.granularity + (utils.project(point[0], this.tileWidth) - this.minTileX);
-        // console.log("Hash: %d", tileHash);
-        // var hashStart = Date.now();
-        var intersects = this.tiles[tileHash];
-        // this.timeHashing += Date.now() - hashStart;
+    var minX = this.minX = Math.min.apply(null, xVertices);
+    var minY = this.minY = Math.min.apply(null, yVertices);
+    var maxX = this.maxX = Math.max.apply(null, xVertices);
+    var maxY = this.maxY = Math.max.apply(null, yVertices);
 
-        if (intersects === 'i') {
-            // this.testsInside++;
-            return true;
-        } else if (intersects === 'x') {
-            // this.testsIntersecting++;
-            var inside = utils.pointInPolygon(point, this.vertices);
-            if (!inside || !this.holes) {
-                return inside;
-            }
-            // If we do have holes cut out, and the point falls within the outer
-            // ring, ensure no inner rings exclude this point
-            for (var i = 0, hole; hole = this.holes[i]; i++) {
-                if (utils.pointInPolygon(point, hole)) {
-                    return false;
+    var xRange = maxX - minX;
+    var yRange = maxY - minY;
+
+    var tileWidth = this.tileWidth = xRange / this.granularity;
+    var tileHeight = this.tileHeight = yRange / this.granularity;
+
+    this.minTileX = utils.project(minX, tileWidth);
+    this.minTileY = utils.project(minY, tileHeight);
+    this.maxTileX = utils.project(maxX, tileWidth);
+    this.maxTileY = utils.project(maxY, tileHeight);
+
+    this.setExclusionTiles(this.vertices, true);
+    if (this.holes) {
+        this.holes.forEach(function(hole) {
+            this.setExclusionTiles(hole, false);
+        }.bind(this));
+    }
+};
+
+Geofence.prototype.setExclusionTiles = function(vertices, inclusive) {
+    var bBoxPoly;
+    var tileHash;
+
+    for (var tileX = this.minTileX; tileX <= this.maxTileX; tileX++) {
+        for (var tileY = this.minTileY; tileY <= this.maxTileY; tileY++) {
+            tileHash = (tileY - this.minTileY) * this.granularity + (tileX - this.minTileX);
+            bBoxPoly = [
+                [tileX * this.tileWidth, tileY * this.tileHeight],
+                [(tileX + 1) * this.tileWidth, tileY * this.tileHeight],
+                [(tileX + 1) * this.tileWidth, (tileY + 1) * this.tileHeight],
+                [tileX * this.tileWidth, (tileY + 1) * this.tileHeight],
+                [tileX * this.tileWidth, tileY * this.tileHeight]
+            ];
+
+            if (utils.haveIntersectingEdges(bBoxPoly, vertices) ||
+                utils.hasPointInPolygon(vertices, bBoxPoly)) {
+                this.tiles[tileHash] = 'x';
+            // If the geofence doesn't have any points inside the tile bbox, then if the bbox has any point inside the geofence
+            // the bbox has all the points inside the geofence
+            } else if (utils.hasPointInPolygon(bBoxPoly, vertices)) {
+                if (inclusive) {
+                    this.tiles[tileHash] = 'i';
+                } else {
+                    this.tiles[tileHash] = 'o';
                 }
-            }
-            return true;
-        } else {
-            // this.testsOutside++;
-            return false;
+            } // else all points are outside the poly
         }
-    },
+    }
+};
 
-    setInclusionTiles: function() {
-        var xVertices = this.vertices.map(function(point) { return point[0]; });
-        var yVertices = this.vertices.map(function(point) { return point[1]; });
-
-        var minX = this.minX = Math.min.apply(null, xVertices);
-        var minY = this.minY = Math.min.apply(null, yVertices);
-        var maxX = this.maxX = Math.max.apply(null, xVertices);
-        var maxY = this.maxY = Math.max.apply(null, yVertices);
-
-        var xRange = maxX - minX;
-        var yRange = maxY - minY;
-
-        var tileWidth = this.tileWidth = xRange / this.granularity;
-        var tileHeight = this.tileHeight = yRange / this.granularity;
-
-        var minTileX = this.minTileX = utils.project(minX, tileWidth);
-        var minTileY = this.minTileY = utils.project(minY, tileHeight);
-        var maxTileX = this.maxTileX = utils.project(maxX, tileWidth);
-        var maxTileY = this.maxTileY = utils.project(maxY, tileHeight);
-
-        this.setExclusionTiles(this.vertices, true);
-        if (this.holes) {
-            this.holes.forEach(function(hole) {
-                this.setExclusionTiles(hole, false);
-            }.bind(this));
-        }
-    },
-
-    setExclusionTiles: function(vertices, inclusive) {
-        var bBoxPoly;
-        var tileHash;
-
-        for (var tileX = this.minTileX; tileX <= this.maxTileX; tileX++) {
-            for (var tileY = this.minTileY; tileY <= this.maxTileY; tileY++) {
-                tileHash = (tileY - this.minTileY) * this.granularity + (tileX - this.minTileX);
-                bBoxPoly = [
-                    [tileX * this.tileWidth, tileY * this.tileHeight],
-                    [(tileX + 1) * this.tileWidth, tileY * this.tileHeight],
-                    [(tileX + 1) * this.tileWidth, (tileY + 1) * this.tileHeight],
-                    [tileX * this.tileWidth, (tileY + 1) * this.tileHeight],
-                    [tileX * this.tileWidth, tileY * this.tileHeight]
-                ];
-
-                if (utils.haveIntersectingEdges(bBoxPoly, vertices) ||
-                    utils.hasPointInPolygon(vertices, bBoxPoly)) {
-                    this.tiles[tileHash] = 'x';
-                // If the geofence doesn't have any points inside the tile bbox, then if the bbox has any point inside the geofence
-                // the bbox has all the points inside the geofence
-                } else if (utils.hasPointInPolygon(bBoxPoly, vertices)) {
-                    if (inclusive) {
-                        this.tiles[tileHash] = 'i';
-                    } else {
-                        this.tiles[tileHash] = 'o';
-                    }
-                } // else all points are outside the poly
-            }
-        }
-    },
-
-    save: function(full) {
-        if (full === false) {
-            return {
-                version: this.version,
-                vertices: this.vertices,
-                holes: this.holes,
-                granularity: this.granularity
-            };
-        } else {
-            return {
-                version: this.version,
-                vertices: this.vertices,
-                holes: this.holes,
-                granularity: this.granularity,
-                minX: this.minX,
-                maxX: this.maxX,
-                minY: this.minY,
-                maxY: this.maxY,
-                tileWidth: this.tileWidth,
-                tileHeight: this.tileHeight,
-                minTileX: this.minTileX,
-                maxTileX: this.maxTileX,
-                minTileY: this.minTileY,
-                maxTileY: this.maxTileY,
-                tiles: this.tiles
-            };
-        }
+Geofence.prototype.save = function(full) {
+    if (full === false) {
+        return {
+            version: this.version,
+            vertices: this.vertices,
+            holes: this.holes,
+            granularity: this.granularity
+        };
+    } else {
+        return {
+            version: this.version,
+            vertices: this.vertices,
+            holes: this.holes,
+            granularity: this.granularity,
+            minX: this.minX,
+            maxX: this.maxX,
+            minY: this.minY,
+            maxY: this.maxY,
+            tileWidth: this.tileWidth,
+            tileHeight: this.tileHeight,
+            minTileX: this.minTileX,
+            maxTileX: this.maxTileX,
+            minTileY: this.minTileY,
+            maxTileY: this.maxTileY,
+            tiles: this.tiles
+        };
     }
 };
 

--- a/test/test_geofence.js
+++ b/test/test_geofence.js
@@ -114,6 +114,41 @@ describe('Geofence.inside()', function() {
         expect(gfTime).to.be.below(inTime);
         console.log("iterations: %d, innout: %dms, pointinpolygon: %dms", iterations, gfTime, inTime);
     });
+
+    describe('event emission', function() {
+
+        var polygon = [
+            [0, 0],
+            [5, 0],
+            [5, 5],
+            [0, 5]
+        ];
+        var geofence = new Geofence(polygon);
+
+        it('should emit "inside" for a point fully inside of the polygon', function(done) {
+            geofence.on('inside', function(point) {
+                expect(point.toString()).to.equal([2, 2].toString());
+                done();
+            });
+            geofence.inside([2, 2]);
+        });
+
+        it('should emit "outside" for a point fully outside of the polygon', function(done) {
+            geofence.on('outside', function(point) {
+                expect(point.toString()).to.equal([6, 6].toString());
+                done();
+            });
+            geofence.inside([6, 6]);
+        });
+
+        it('should emit "intersection" for a point on the edge of the polygon', function(done) {
+            geofence.on('intersection', function(point) {
+                expect(point.toString()).to.equal([5, 5].toString());
+                done();
+            });
+            geofence.inside([5, 5]);
+        });
+    });
 });
 
 describe('Complex polygons', function() {


### PR DESCRIPTION
cc @erikformella @countrodrigo 

Turn the Geofence object into an EventEmitter and emit events on "inside", "outside" and "intersection" to see what percentage of the time is spent falling back to `point-in-polygon` versus short-circuiting via the fast lookup cache.

This will let us hand-tune the granularity for fewer cache misses on particularly onerous geofence geometries where a cache miss is 2-3 orders of magnitude more expensive.
